### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/components/PlayoffYearSelector.js
+++ b/src/app/components/PlayoffYearSelector.js
@@ -8,7 +8,7 @@ const handlePlayoffYearChange = (e) => {
   if (/^\d+$/.test(year)) { // Ensure the value is numeric
     window.location = `/playoffs/${year}`;
   } else {
-    console.error("Invalid year selected:", year);
+    console.error('Invalid year selected:', year);
   }
 };
 

--- a/src/app/components/PlayoffYearSelector.js
+++ b/src/app/components/PlayoffYearSelector.js
@@ -5,7 +5,11 @@ import { PropTypes } from 'prop-types';
 
 const handlePlayoffYearChange = (e) => {
   const year = e.target.value;
-  window.location = `/playoffs/${year}`;
+  if (/^\d+$/.test(year)) { // Ensure the value is numeric
+    window.location = `/playoffs/${year}`;
+  } else {
+    console.error("Invalid year selected:", year);
+  }
 };
 
 const PlayoffYearSelector = ({ seasons, year }) => {


### PR DESCRIPTION
Potential fix for [https://github.com/stephenyeargin/nhl-nextjs/security/code-scanning/7](https://github.com/stephenyeargin/nhl-nextjs/security/code-scanning/7)

To fix the issue, we need to validate and sanitize the `e.target.value` before using it to construct the URL. A simple and effective approach is to ensure that the value is a valid number (since `seasons` is an array of numbers). This can be done using `Number.isInteger` or a regular expression to allow only numeric values. If the value is invalid, we can either ignore the change or handle it gracefully (e.g., show an error message).

The fix involves modifying the `handlePlayoffYearChange` function to validate the `year` before constructing the URL. If the `year` is invalid, the function should not update `window.location`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
